### PR TITLE
Enabling prometheus endpoint in Payment service

### DIFF
--- a/rsbc-ride-payment-query-svc/jh-etk-common/src/main/java/bcgov/jh/etk/jhetkcommon/model/PathConst.java
+++ b/rsbc-ride-payment-query-svc/jh-etk-common/src/main/java/bcgov/jh/etk/jhetkcommon/model/PathConst.java
@@ -14,6 +14,9 @@ public class PathConst {
 
 	/** The Constant PATH for ready service */
 	public final static String PATH_READY_REQUEST = "/ready";
+
+	/** The Constant PATH for actuator endpoints */
+    public final static String PATH_ACTUATOR = "/actuator/**";
 	
 	/** The Constant PATH for test service. */
 	public final static String PATH_TEST_REQUEST = "/test";

--- a/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/pom.xml
+++ b/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/pom.xml
@@ -74,6 +74,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/src/main/java/bcgov/jh/etk/paymentsvc/config/SecurityConfig.java
+++ b/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/src/main/java/bcgov/jh/etk/paymentsvc/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package bcgov.jh.etk.paymentsvc.config;
 
 import static bcgov.jh.etk.jhetkcommon.model.PathConst.PATH_PING_REQUEST;
 import static bcgov.jh.etk.jhetkcommon.model.PathConst.PATH_READY_REQUEST;
+import static bcgov.jh.etk.jhetkcommon.model.PathConst.PATH_ACTUATOR;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.authorizeHttpRequests((auth) -> {
-			auth.requestMatchers(PATH_PING_REQUEST, PATH_READY_REQUEST).permitAll();
+			auth.requestMatchers(PATH_PING_REQUEST, PATH_READY_REQUEST, PATH_ACTUATOR).permitAll();
 			auth.anyRequest().authenticated();
 		}).httpBasic(withDefaults());
 		return http.build();

--- a/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/src/main/resources/application.properties
+++ b/rsbc-ride-payment-query-svc/jh-etk-paymentsvc/src/main/resources/application.properties
@@ -55,3 +55,7 @@ db.version=${DATABASE_VERSION:0}
 
 pod.ip=${POD_IP:notset}
 pod.name=${POD_NAME:notset}
+
+# Enable Prometheus endpoint
+management.endpoints.web.exposure.include=prometheus
+management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
Enhance RIDE monitoring to support TCO Pay service (RIDE-352)

Created and exposed prometheus endpoint

/paymentsvc/api/v1/actuator/prometheus

![image](https://github.com/user-attachments/assets/14fb9ac0-fb1e-4c9d-9fd6-4745c1746500)
